### PR TITLE
Release v1.0.1 — CLI tool scoring fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npx-ray",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "X-ray vision for npm packages — security scanner that audits source code, detects obfuscation, and flags supply chain risks before you install",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,7 +36,7 @@ import { checkGitHubHealth } from './github.js';
 import { diffSource } from './diff.js';
 import { scanMcpConfigs } from './mcp.js';
 
-const VERSION = '1.0.0';
+const VERSION = '1.0.1';
 
 /**
  * Run the full scan pipeline for a single package.


### PR DESCRIPTION
## Summary
- Bumps version to 1.0.1 (`package.json` + `cli.ts`)
- Includes the CLI tool aggressiveness fix from #1

## Changes in this release
- **Static scanner**: Detects CLI tools via `bin` field and downgrades shell execution findings (`child_process`, `exec`, `spawn`, etc.) from `critical` to `info`
- `eval()` and `new Function()` remain critical regardless of package type
- Summary output notes when a CLI tool is detected for transparency

## Test plan
- [x] `npm run build` compiles cleanly
- [x] All 107 tests pass
- [ ] Merge to main, create GitHub release `v1.0.1` to trigger npm publish

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)