### PR TITLE
Fix scoring false positives for legitimate packages

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -117,7 +117,7 @@ async function scanPackage(
     }
 
     // Step 6: Calculate score
-    const { score, grade, verdict } = calculateScore(scanners, github, diff);
+    const { score, grade, verdict } = calculateScore(scanners, github, diff, meta);
 
     // Step 7: Build report
     const duration = Date.now() - startTime;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -227,11 +227,18 @@ export async function fetchPackageMetadata(target: string): Promise<PackageMetad
     license = (lic as Record<string, unknown>).type as string || '';
   }
 
-  // Extract publisher info
+  // Extract publisher info and trusted publisher (provenance via OIDC)
   let publisher = '';
-  const npmUser = manifest._npmUser as Record<string, string> | undefined;
+  let trustedPublisher: { id: string } | undefined;
+  const npmUser = manifest._npmUser as Record<string, unknown> | undefined;
   if (npmUser?.name) {
-    publisher = npmUser.name;
+    publisher = npmUser.name as string;
+  }
+  if (npmUser?.trustedPublisher && typeof npmUser.trustedPublisher === 'object') {
+    const tp = npmUser.trustedPublisher as Record<string, unknown>;
+    if (tp.id && typeof tp.id === 'string') {
+      trustedPublisher = { id: tp.id };
+    }
   }
 
   // Extract publish date from the time field
@@ -260,5 +267,6 @@ export async function fetchPackageMetadata(target: string): Promise<PackageMetad
     optionalDependencies: (manifest.optionalDependencies as Record<string, string>) || {},
     scripts: (manifest.scripts as Record<string, string>) || {},
     maintainers,
+    trustedPublisher,
   };
 }

--- a/src/scanners/ioc.ts
+++ b/src/scanners/ioc.ts
@@ -29,29 +29,168 @@ const IPV4_PATTERN = /\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)\.){3}(?:25[0-5]
 
 /** Domains/URLs to exclude (common, expected, non-suspicious). */
 const IGNORED_DOMAINS = [
+  // npm / Node ecosystem
   'registry.npmjs.org',
   'nodejs.org',
-  'github.com',
-  'raw.githubusercontent.com',
   'npmjs.com',
   'www.npmjs.com',
   'docs.npmjs.com',
+  'yarnpkg.com',
+  'pnpm.io',
+
+  // Code hosting / VCS
+  'github.com',
+  'raw.githubusercontent.com',
+  'gist.github.com',
+  'gitlab.com',
+  'bitbucket.org',
+
+  // Standards / specs
   'opensource.org',
   'spdx.org',
   'creativecommons.org',
-  'shields.io',
-  'img.shields.io',
-  'badge.fury.io',
   'www.w3.org',
   'schema.org',
   'json-schema.org',
   'tc39.es',
+  'ecma-international.org',
+  'whatwg.org',
+  'ietf.org',
+
+  // Documentation / reference
   'developer.mozilla.org',
+  'mozilla.org',
+  'wikipedia.org',
+  'en.wikipedia.org',
+  'stackoverflow.com',
+  'readthedocs.io',
+  'docs.rs',
+
+  // JS tooling / frameworks
   'eslint.org',
   'prettier.io',
   'jestjs.io',
   'typescriptlang.org',
   'www.typescriptlang.org',
+  'babeljs.io',
+  'webpack.js.org',
+  'vitejs.dev',
+  'rollupjs.org',
+  'esbuild.github.io',
+  'reactjs.org',
+  'react.dev',
+  'vuejs.org',
+  'angular.io',
+  'svelte.dev',
+  'nextjs.org',
+  'nuxt.com',
+  'deno.land',
+
+  // Cloud / SaaS / infrastructure
+  'googleapis.com',
+  'google.com',
+  'www.google.com',
+  'cloud.google.com',
+  'firebase.google.com',
+  'firebaseio.com',
+  'microsoft.com',
+  'azure.com',
+  'windows.net',
+  'amazonaws.com',
+  'aws.amazon.com',
+  'cloudflare.com',
+  'cloudflareinsights.com',
+  'heroku.com',
+  'digitalocean.com',
+  'vercel.com',
+  'netlify.com',
+  'netlify.app',
+  'railway.app',
+  'render.com',
+  'fly.io',
+  'supabase.com',
+  'supabase.co',
+
+  // AI / ML
+  'anthropic.com',
+  'openai.com',
+  'huggingface.co',
+  'cohere.com',
+
+  // Auth / identity
+  'auth0.com',
+  'okta.com',
+  'clerk.dev',
+  'clerk.com',
+
+  // Monitoring / analytics / services
+  'sentry.io',
+  'sentry.dev',
+  'datadog.com',
+  'newrelic.com',
+  'grafana.com',
+  'segment.com',
+  'mixpanel.com',
+  'amplitude.com',
+  'logflare.app',
+
+  // Payments / communication
+  'stripe.com',
+  'twilio.com',
+  'sendgrid.com',
+  'mailgun.com',
+  'postmarkapp.com',
+
+  // Productivity / collaboration
+  'linear.app',
+  'notion.com',
+  'notion.so',
+  'slack.com',
+  'discord.com',
+  'discord.gg',
+
+  // Social media
+  'x.com',
+  'twitter.com',
+  'facebook.com',
+  'linkedin.com',
+  'youtube.com',
+
+  // Package registries (non-npm)
+  'pypi.org',
+  'crates.io',
+  'rubygems.org',
+  'packagist.org',
+  'pkg.go.dev',
+  'mvnrepository.com',
+  'nuget.org',
+
+  // Container / CI
+  'docker.com',
+  'hub.docker.com',
+  'ghcr.io',
+  'circleci.com',
+  'travis-ci.org',
+  'travis-ci.com',
+
+  // Badges / shields
+  'shields.io',
+  'img.shields.io',
+  'badge.fury.io',
+  'badgen.net',
+  'codecov.io',
+  'coveralls.io',
+  'david-dm.org',
+  'snyk.io',
+
+  // CDNs
+  'unpkg.com',
+  'cdn.jsdelivr.net',
+  'cdnjs.cloudflare.com',
+  'esm.sh',
+  'skypack.dev',
+
+  // Localhost / reserved
   'localhost',
   '127.0.0.1',
   '0.0.0.0',
@@ -408,7 +547,7 @@ export async function scanIoc(pkgDir: string): Promise<ScannerResult> {
     const firstLoc = ioc.files[0];
     const label = ioc.decodedFrom
       ? `URL (${ioc.decodedFrom}-decoded)`
-      : 'URL';
+      : 'External URL';
     const evidenceParts: string[] = [];
     if (ioc.decodedFrom) evidenceParts.push(`Decoded from ${ioc.decodedFrom} obfuscation`);
     if (ioc.files.length > 1) evidenceParts.push(`Found in ${ioc.files.length} location(s)`);
@@ -426,7 +565,7 @@ export async function scanIoc(pkgDir: string): Promise<ScannerResult> {
     const firstLoc = ioc.files[0];
     const label = ioc.decodedFrom
       ? `IP (${ioc.decodedFrom}-decoded)`
-      : 'IP';
+      : 'External IP';
     const evidenceParts: string[] = [];
     if (ioc.decodedFrom) evidenceParts.push(`Decoded from ${ioc.decodedFrom} obfuscation`);
     if (ioc.files.length > 1) evidenceParts.push(`Found in ${ioc.files.length} location(s)`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,8 @@ export interface PackageMetadata {
   scripts: Record<string, string>;
   /** All maintainers. */
   maintainers: Array<{ name: string; email?: string }>;
+  /** Trusted publisher info (npm provenance via OIDC). Undefined if not present. */
+  trustedPublisher?: { id: string };
 }
 
 /** GitHub repository health info. */


### PR DESCRIPTION
## Summary

- Fix false positives causing trusted packages (eslint, prettier, typescript, mcporter) to score D/F
- Skip test files in static + obfuscation scanners
- Classify large string arrays as data tables vs obfuscation (rotation function + readability check)
- Raise entropy thresholds and downgrade minified code to info
- Add diminishing returns to scorer (logarithmic scaling replaces linear deduction)
- Reduce publisher-mismatch penalty for popular repos; eliminate for verified CI provenance
- Cap diff deduction with diminishing returns
- Extract npm trusted publisher (OIDC provenance) and display in report
- Expand IOC allowlist (~130 domains) and rename "IOC" → "Network References"

### Score improvements

| Package | Before | After |
|---|---|---|
| chalk | 90/A | 97/A |
| mcporter | 65/D | 69/D |
| typescript | 50/F | 59/F |
| eslint | 35/F | 47/F |
| prettier | 40/F | 52/F |

## Test plan

- [x] `npm run build` — clean compile
- [x] `npm test` — 119/119 tests pass
- [x] New tests: diminishing returns, test file exclusion, minification detection, string array classification, IOC domain filtering, provenance scoring
- [x] Scanned mcporter, eslint, prettier, typescript, chalk — verified score improvements
- [x] Existing malicious pattern tests still pass (eval+obfuscation+postinstall = F)

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)