### PR TITLE
Fix prettier false positives: bundled hex, diff dirs, CLI network calls

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -23,6 +23,7 @@ const USER_AGENT = 'npx-ray/1.0.0';
 const BUILD_DIR_PREFIXES = [
   'dist/', 'lib/', 'build/', '.next/', 'out/',
   'prebuilds/', 'compiled/', 'esm/', 'cjs/',
+  'plugins/', 'internal/', 'vendor/', 'bin/',
 ];
 
 /**
@@ -164,6 +165,13 @@ function isExpectedBuildFile(
 
   // Native addon binaries (.node) are build artifacts
   if (filePath.endsWith('.node')) {
+    return true;
+  }
+
+  // Common generated files
+  const basename = filePath.split('/').pop() || '';
+  if (basename === 'THIRD-PARTY-NOTICES.md' || basename === 'NOTICES' ||
+      basename === 'LICENSE.md' || basename === 'CHANGELOG.md') {
     return true;
   }
 

--- a/src/scanners/obfuscation.ts
+++ b/src/scanners/obfuscation.ts
@@ -30,23 +30,20 @@ function isTestFile(relPath: string): boolean {
 }
 
 /**
- * Heuristic: does the file look like minified (not obfuscated) code?
- * Minified code has long lines and retains JS keywords but lacks heavy hex escapes.
+ * Heuristic: does the file look like minified or bundled code?
+ * Bundled/minified code has long lines and retains JS keywords.
+ * Bundled parsers may also contain hex-encoded character tables —
+ * that doesn't make them obfuscated. Obfuscation is detected separately
+ * via string array rotation patterns.
  */
 function looksMinified(content: string): boolean {
   const lines = content.split('\n');
   const hasLongLines = lines.some(l => l.length > 500);
   if (!hasLongLines) return false;
 
-  // Check for JS keywords that survive minification
+  // Check for JS keywords that survive minification/bundling
   const jsKeywords = /\b(function|return|var|let|const|if|else|for|while|class|export|import|typeof|instanceof)\b/;
-  const hasKeywords = jsKeywords.test(content);
-
-  // Check for heavy hex escapes (obfuscation indicator)
-  const hexMatches = content.match(/(\\x[0-9a-fA-F]{2}){4,}/g);
-  const heavyHex = hexMatches !== null && hexMatches.length > 5;
-
-  return hasKeywords && !heavyHex;
+  return jsKeywords.test(content);
 }
 
 /** Minimum file size to run entropy analysis (skip tiny files). */

--- a/src/scanners/static.ts
+++ b/src/scanners/static.ts
@@ -53,15 +53,15 @@ const PATTERNS: Pattern[] = [
   // exec() is checked separately to avoid matching execSync/execFile and regex .exec()
   { regex: /(?<!\.)(?<!\w)exec\s*\(/, severity: 'critical', message: 'exec() — shell command execution', cliExpected: true, checkStringContext: true },
 
-  // Network calls (warning)
-  { regex: /\bfetch\s*\(/, severity: 'warning', message: 'fetch() — network request', checkStringContext: true },
-  { regex: /\bhttp\.request\b/, severity: 'warning', message: 'http.request — network request' },
-  { regex: /\bhttps\.request\b/, severity: 'warning', message: 'https.request — network request' },
+  // Network calls (warning, but expected for CLI tools that fetch updates/plugins)
+  { regex: /\bfetch\s*\(/, severity: 'warning', message: 'fetch() — network request', checkStringContext: true, cliExpected: true },
+  { regex: /\bhttp\.request\b/, severity: 'warning', message: 'http.request — network request', cliExpected: true },
+  { regex: /\bhttps\.request\b/, severity: 'warning', message: 'https.request — network request', cliExpected: true },
   { regex: /\bXMLHttpRequest\b/, severity: 'warning', message: 'XMLHttpRequest — network request' },
-  { regex: /\baxios\b/, severity: 'warning', message: 'axios — HTTP client' },
-  { regex: /\bgot\s*\(/, severity: 'warning', message: 'got() — HTTP client', checkStringContext: true },
-  { regex: /\bnode-fetch\b/, severity: 'warning', message: 'node-fetch — HTTP client' },
-  { regex: /\bundici\b/, severity: 'warning', message: 'undici — HTTP client' },
+  { regex: /\baxios\b/, severity: 'warning', message: 'axios — HTTP client', cliExpected: true },
+  { regex: /\bgot\s*\(/, severity: 'warning', message: 'got() — HTTP client', checkStringContext: true, cliExpected: true },
+  { regex: /\bnode-fetch\b/, severity: 'warning', message: 'node-fetch — HTTP client', cliExpected: true },
+  { regex: /\bundici\b/, severity: 'warning', message: 'undici — HTTP client', cliExpected: true },
 
   // Dynamic requires (warning, but expected for CLI tools that load plugins/configs)
   { regex: /\brequire\s*\(\s*[^'"`\s]/, severity: 'warning', message: 'Dynamic require() — variable module path', checkStringContext: true, cliExpected: true },


### PR DESCRIPTION
## Summary

- Remove `!heavyHex` check from `looksMinified()` — bundled parsers (Flow, Babel) legitimately contain hex character tables alongside JS keywords. Obfuscation is already detected via string array rotation patterns separately.
- Add `plugins/`, `internal/`, `vendor/`, `bin/` to diff `BUILD_DIR_PREFIXES` so bundled output in those directories is recognized as expected build artifacts
- Recognize common generated files (`THIRD-PARTY-NOTICES.md`, etc.) as build artifacts
- Mark `fetch()` and HTTP client patterns (`http.request`, `axios`, `got`, `node-fetch`, `undici`) as `cliExpected` for CLI tools

## Results

| Package | Before | After |
|---|---|---|
| prettier | 65/D | **77/C** |
| mcporter | 92/A | 92/A |
| eslint | 78/C | 78/C |
| typescript | 84/B | 84/B |
| chalk | 97/A | 97/A |

## Test plan

- [x] All 123 tests pass
- [x] Scanned mcporter, eslint, prettier, typescript, chalk — verified scores

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)