### PR TITLE
Read CLI version from package.json instead of hardcoded string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npx-ray",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npx-ray",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npx-ray",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "X-ray vision for npm packages — security scanner that audits source code, detects obfuscation, and flags supply chain risks before you install",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,8 @@ import { Command } from 'commander';
 import ora from 'ora';
 import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import type {
   ScanReport,
@@ -36,7 +37,10 @@ import { checkGitHubHealth } from './github.js';
 import { diffSource } from './diff.js';
 import { scanMcpConfigs } from './mcp.js';
 
-const VERSION = '1.0.1';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const VERSION = JSON.parse(
+  await fs.readFile(join(__dirname, '..', 'package.json'), 'utf-8'),
+).version as string;
 
 /**
  * Run the full scan pipeline for a single package.


### PR DESCRIPTION
## Summary
- Replace hardcoded `const VERSION = '1.0.1'` with dynamic read from `package.json`
- Version now always matches the published package version
- Bump to 1.0.3

## Test plan
- [x] `node dist/cli.js --version` outputs `1.0.3`
- [x] 125 tests pass

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)